### PR TITLE
Make hashbang portable

### DIFF
--- a/raspbmirror.py
+++ b/raspbmirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright 2018 Peter Green
 # Released under the MIT/Expat license, see doc/COPYING


### PR DESCRIPTION
A tiny change that makes the script run cross-platform unmodified. I run it on FreeBSD and have to change it manually every time I update it.