### PR TITLE
Add a --nolock option to raspbmirror.

### DIFF
--- a/raspbmirror.py
+++ b/raspbmirror.py
@@ -42,10 +42,13 @@ parser.add_argument("--debugskippool",help="skip downloading pool data, only dow
 
 parser.add_argument("--distswhitelist", help="specify comman seperated list of distributions")
 
+parser.add_argument("--nolock", help="don't try to lock the target directory", action="store_true")
+
 args = parser.parse_args()
 
-lockfd = os.open('.',os.O_RDONLY)
-fcntl.flock(lockfd,fcntl.LOCK_EX | fcntl.LOCK_NB)
+if not args.nolock:
+	lockfd = os.open('.',os.O_RDONLY)
+	fcntl.flock(lockfd,fcntl.LOCK_EX | fcntl.LOCK_NB)
 
 def addfilefromdebarchive(filestoverify,filequeue,filename,sha256,size):
 	size = int(size)


### PR DESCRIPTION
We need to run raspbmirror on a freebsd box that has the target directory
NFS-mounted, where flock will not work:

```
Traceback (most recent call last):
  File "/usr/local/bin/raspbmirror.py", line 48, in <module>
    fcntl.flock(lockfd,fcntl.LOCK_EX | fcntl.LOCK_NB)
OSError: [Errno 45] Operation not supported
```

--nolock lets us move the mutual exclusion outside the script.