### PR TITLE
raspbmirror: robustness against inconsistent on-disk state & --repair option

### DIFF
--- a/raspbmirror.py
+++ b/raspbmirror.py
@@ -175,7 +175,8 @@ def getfile(path,sha256,size):
 	#	os.utime(hashfn,(ts,ts))
 	if len(os.path.dirname(path)) > 0:
 		os.makedirs(os.path.dirname(path),exist_ok=True)
-	if os.path.isfile(makenewpath(path)): # "new" file already exists, lets check the hash
+	havenewfile = os.path.isfile(makenewpath(path))
+	if havenewfile: # "new" file already exists, lets check the hash
 		fn = makenewpath(path)
 		sha256hashed, tl = getfilesha256andsize(fn)
 		if (sha256 == sha256hashed) and (size == tl):
@@ -184,7 +185,7 @@ def getfile(path,sha256,size):
 			return # no download needed but rename is
 	if os.path.isfile(path): # file already exists
 		if (size == os.path.getsize(path)): #no point reading the data and calculating a hash if the size does not match
-			if (not args.repair) and (path in oldknownfiles):
+			if (not args.repair) and (path in oldknownfiles) and (not havenewfile):
 				#shortcut exit if file is unchanged, we skip this if a "new" file was detected because
 				#that means some sort of update was going on to the file and may need to be finished/cleaned up.
 				oldsha256,oldsize,oldstatus = oldknownfiles[path]
@@ -194,7 +195,7 @@ def getfile(path,sha256,size):
 			sha256hashed, tl = getfilesha256andsize(path)
 			if (sha256 == sha256hashed) and (size == tl):
 				print('existing file '+path.decode('ascii')+' matched by hash and size')
-				if os.path.isfile(makenewpath(path)):
+				if havenewfile:
 					#if file is up to date but a "new" file exists and is bad
 					#(we wouldn't have got this far if it was good)
 					#schedule the "new" file for removal by adding it to "basefiles"

--- a/raspbmirror.py
+++ b/raspbmirror.py
@@ -180,14 +180,15 @@ def getfile(path,sha256,size):
 			print('existing file '+path.decode('ascii')+' matched by hash and size')
 			fileupdates.add(path)
 			return # no download needed but rename is
-	elif path in oldknownfiles: 
-		#shortcut exit if file is unchanged, we skip this if a "new" file was detected because
-		#that means some sort of update was going on to the file and may need to be finished/cleaned up.
-		oldsha256,oldsize,oldstatus = oldknownfiles[path]
-		if (oldsha256 == sha256) and (oldsize == size) and (oldstatus != 'F'):
-			return # no update needed
 	if os.path.isfile(path): # file already exists
 		if (size == os.path.getsize(path)): #no point reading the data and calculating a hash if the size does not match
+			if path in oldknownfiles:
+				#shortcut exit if file is unchanged, we skip this if a "new" file was detected because
+				#that means some sort of update was going on to the file and may need to be finished/cleaned up.
+				oldsha256,oldsize,oldstatus = oldknownfiles[path]
+				if (oldsha256 == sha256) and (oldsize == size) and (oldstatus != 'F'):
+					return # no update needed
+
 			sha256hashed, tl = getfilesha256andsize(path)
 			if (sha256 == sha256hashed) and (size == tl):
 				print('existing file '+path.decode('ascii')+' matched by hash and size')

--- a/raspbmirror.py
+++ b/raspbmirror.py
@@ -44,6 +44,8 @@ parser.add_argument("--distswhitelist", help="specify comman seperated list of d
 
 parser.add_argument("--nolock", help="don't try to lock the target directory", action="store_true")
 
+parser.add_argument("--repair", help="during mirroring, verify that all on-disk files match the expected sha256", action="store_true")
+
 args = parser.parse_args()
 
 if not args.nolock:
@@ -182,7 +184,7 @@ def getfile(path,sha256,size):
 			return # no download needed but rename is
 	if os.path.isfile(path): # file already exists
 		if (size == os.path.getsize(path)): #no point reading the data and calculating a hash if the size does not match
-			if path in oldknownfiles:
+			if (not args.repair) and (path in oldknownfiles):
 				#shortcut exit if file is unchanged, we skip this if a "new" file was detected because
 				#that means some sort of update was going on to the file and may need to be finished/cleaned up.
 				oldsha256,oldsize,oldstatus = oldknownfiles[path]


### PR DESCRIPTION
This makes two changes:

1) rather than assuming that the on-disk mirror is self-consistent and all files listed in Packages et al do exist, verify that they do at least exist with the right size

2) add a `--repair` option that also re-verifies that the existing file sha256 sums match those listed in the existing Packages

The background here is that due to external issues (not the fault of raspmirror) our mirror became inconsistent, with some package files that should be present per Packages actually being missing. raspbmirror in subsequent runs never noticed the problem and it took a while to work out why it would not download the missing files to fix the mirror state. Testing for existence/size is cheap and should help with this sort of case.

`--repair` is extra paranoia to guard against more subtle corruption.
